### PR TITLE
Fix Vercel deployment runtime error

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
   adapter: vercel({
     analytics: true,
     imageService: true,
-    webAnalytics: true
+    webAnalytics: true,
+    functionPerRoute: false
   })
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "src/pages/api/**/*.ts": {
+      "runtime": "nodejs20.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
• Fix Vercel deployment failing due to invalid Node.js runtime
• Update configuration to use supported Node.js 20.x runtime

## Issue
Vercel deployment was failing with error:
```
The following Serverless Functions contain an invalid "runtime":
- _render (nodejs18.x)
```

## Changes Made
### Vercel Configuration
- **Added `vercel.json`**: Specifies Node.js 20.x runtime for API functions
- **Updated `astro.config.mjs`**: Added `functionPerRoute: false` for better compatibility

### Technical Details
- Node.js 18.x is no longer supported on Vercel
- Node.js 20.x is the current supported LTS version
- Configuration ensures all API routes work with serverless functions

## Test plan
- [x] Vercel configuration validates without runtime errors
- [x] API endpoints maintain compatibility
- [x] Serverless functions deploy successfully

This is a deployment-only fix with no functional changes to the application.